### PR TITLE
Update .gitignore file: add rule to ignore .eggs directory

### DIFF
--- a/back/.gitignore
+++ b/back/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
+.eggs
 *.egg-info
 dist


### PR DESCRIPTION
This directory is created after the installation because I use `python setup.py develop` to install the plugin for development purpose.
