### PR TITLE
Disable notification by default

### DIFF
--- a/back/taiga_contrib_hipchat/tasks.py
+++ b/back/taiga_contrib_hipchat/tasks.py
@@ -35,7 +35,6 @@ def _get_type(obj):
 
 
 def _send_request(url, data):
-    data["notify"] = True
     serialized_data = UnicodeJSONRenderer().render(data)
     headers = {
         'Content-type': 'application/json',


### PR DESCRIPTION
The HipChat API has Notify defaulting to False for a reason. It causes unnecessary interruptions to users of HipChat rooms, and basically makes alerts useless as usually the alert is actionless information. This commit disables the the notification, reverting the behavior to the API default. If Notify is desired, it should be added as an option to be enabled, not hard-coded.
